### PR TITLE
fix: inherit stdio pipes from parent process

### DIFF
--- a/service-web-core/src/lib/runShellCommands.ts
+++ b/service-web-core/src/lib/runShellCommands.ts
@@ -48,14 +48,12 @@ export default async function runShellCommands(wd: string, cmds: string[], opts:
       concatenatedCommand,
       {
          cwd: wd,
+         stdio: 'inherit',
          // TODO: consider security implications:
          shell: true,
          env: env,
       }
    );
-
-   child.stdout.pipe(process.stdout);
-   child.stderr.pipe(process.stderr);
 
    return new Promise((resolve, reject) => {
       child.on('error', (err) => {


### PR DESCRIPTION
This change fixes color output from child processes, allows the deploy shell commands to request user input, and makes temporary progress output show up (e.g. messages like "Updating CloudFormation stack (33s)").