### PR TITLE
fix: reset lastService iterator

### DIFF
--- a/service-web-cli/src/commands/runForEachDeploymentTarget.ts
+++ b/service-web-cli/src/commands/runForEachDeploymentTarget.ts
@@ -130,6 +130,8 @@ export default async function runForEachDeploymentTarget(web: Web, serviceNames:
             return true;
          });
 
+      lastService = undefined;
+
       for (let link of flatChain) {
          if (lastService !== link[0]) {
             currentService = currentService + 1;


### PR DESCRIPTION
This fixes the regression introduced in 5bcf8204d80a01e5df99a4fcd965c9d4dc842e42 where serial deploys start at "Progress: Service 0 of 1 | Target 1 of 2"