### PR TITLE
fix: make command-failure output concise by default

### DIFF
--- a/service-web-cli/src/cli.ts
+++ b/service-web-cli/src/cli.ts
@@ -244,7 +244,7 @@ function addDeploymentTargetBasedCommand(web: Web, cmdName: string, desc: string
             });
          } catch(err) {
             if (err instanceof ShellCommandError) {
-               console.error(`Error running ${cmdName} for ${s.ID}: ${err}\n${err.stack}`);
+               console.error(`Error running ${cmdName} for ${s.ID}: ${err.message}`);
                process.exit(err.exitCode);
             }
             throw err;

--- a/service-web-core/src/lib/runShellCommands.ts
+++ b/service-web-core/src/lib/runShellCommands.ts
@@ -70,7 +70,7 @@ export default async function runShellCommands(wd: string, cmds: string[], opts:
          if (code === 0) {
             return resolve();
          }
-         reject(new ShellCommandError(`Process exited with code ${code}\n${concatenatedCommand}`));
+         reject(new ShellCommandError(`Process exited with code ${code}`));
       });
    });
 }


### PR DESCRIPTION
Previously, a failed command buried the underlying error: the command chain was embedded in the error message and the CLI printed both the message and the stack (which repeats the message). Default output now shows just the real error plus "Process exited with code N". The full command remains available via --verbose, which already echoes it before the run.